### PR TITLE
Feat/home 상품 리스트 3개 모두 구현, 홈 배너 완성

### DIFF
--- a/lib/core/network/endpoint/product_endpoints.dart
+++ b/lib/core/network/endpoint/product_endpoints.dart
@@ -2,6 +2,19 @@ class ProductEndpoints {
   // 상품 목록 검색
   static const String getProducts = '/api/products';
 
+  static Uri getProductsUri({
+    String? sortBy,
+    String? category,
+  }) {
+    return Uri(
+      path: '/api/products',
+      queryParameters: {
+        if (sortBy != null) 'sortBy': sortBy,
+        if (category != null) 'category': category
+      },
+    );
+  }
+
   // 상품 상세 조회
   static String getProductDetail({required int productId}) =>
       '/api/products/$productId';

--- a/lib/core/utils/formatters.dart
+++ b/lib/core/utils/formatters.dart
@@ -1,0 +1,8 @@
+import 'package:intl/intl.dart';
+
+String formatPrice(int price) {
+  final formatter = NumberFormat('#,###');
+  if (price >= 1000000) return "${formatter.format(price ~/ 1000000)}M 원";
+  if (price >= 10000) return "${formatter.format(price ~/ 10000)}만 원";
+  return "${formatter.format(price)} 원";
+}

--- a/lib/core/utils/formatters.dart
+++ b/lib/core/utils/formatters.dart
@@ -2,7 +2,7 @@ import 'package:intl/intl.dart';
 
 String formatPrice(int price) {
   final formatter = NumberFormat('#,###');
-  if (price >= 1000000) return "${formatter.format(price ~/ 1000000)}M 원";
-  if (price >= 10000) return "${formatter.format(price ~/ 10000)}만 원";
-  return "${formatter.format(price)} 원";
+  if (price >= 1000000) return "${formatter.format(price ~/ 1000000)}M원";
+  if (price >= 10000) return "${formatter.format(price ~/ 10000)}만원";
+  return "${formatter.format(price)}원";
 }

--- a/lib/data/datasource/product_datasource.dart
+++ b/lib/data/datasource/product_datasource.dart
@@ -7,15 +7,18 @@ import '../models/response/product_list_response.dart';
 class ProductDatasource {
   final dio = ApiClient().dio;
 
-  Future<ApiResponse<ProductListResponse>> getProducts() async {
-    final response = await dio.get(ProductEndpoints.getProducts);
+  Future<ApiResponse<ProductListResponse>> getProducts({String? sortBy, String? category,
+  }) async {
+    final uri = ProductEndpoints.getProductsUri(sortBy: sortBy, category: category,
+    );
+
+    final response = await dio.getUri(uri);
 
     if (response.statusCode == 200) {
       return ApiResponse<ProductListResponse>.fromJson(
         response.data,
             (json) => ProductListResponse.fromJson(json as Map<String, dynamic>),
       );
-
     } else {
       throw DioException(
         requestOptions: response.requestOptions,

--- a/lib/data/models/product/product.dart
+++ b/lib/data/models/product/product.dart
@@ -1,15 +1,20 @@
+import 'package:damdiet/data/models/product/product_nutrition.dart';
+
+import '../../../models/Review.dart';
+
+
 class Product {
   final String id;
   final String name;
   final String image;
   final int price;
   final bool isFavorite;
-  final String discount;
-  final String category;
+  final int discount;
+  final String? category;
   final double rating;
-  //final ProductNutrition nutrition;
-  // final List<Review>? reviews;
-  // final List<String>? options;
+  final ProductNutrition attributes;
+  final List<Review>? reviews;
+  final List<String>? options;
 
   Product({
     required this.id,
@@ -18,48 +23,36 @@ class Product {
     required this.price,
     required this.isFavorite,
     required this.discount,
-    required this.category,
+    this.category,
     required this.rating,
-    //required this.nutrition,
-    //this.reviews,
-    //this.options,
+    required this.attributes,
+    this.reviews,
+    this.options,
   });
 
   factory Product.fromJson(Map<String, dynamic> json) {
     return Product(
       id: json['id'] as String,
       name: json['name'] as String,
-      image: json['images'] as String,
-      price: json['price'] as int,
+      image: json['image'] as String,
+      price: json['price'] is int
+          ? json['price'] as int
+          : int.tryParse(json['price']?.toString() ?? '') ?? 0,
       isFavorite: json['isFavorite'] as bool? ?? false,
-      discount: json['discount'] as String? ?? "0",
-      category: json['category'] as String? ?? "닭가슴살",
+      discount: json['discount'] as int,
+      category: json['category'] as String?,
       rating: (json['rating'] as num?)?.toDouble() ?? 0.0,
-      //nutrition: ProductNutrition.fromJson(json),
-      // reviews: json['reviews'] != null
-      //     ? (json['reviews'] as List)
-      //     .map((e) => Review.fromJson(e as Map<String, dynamic>))
-      //     .toList()
-      //     : null,
-      // options: json['options'] != null
-      //     ? List<String>.from(json['options'] as List)
-      //     : null,
+      attributes: ProductNutrition.fromJson(
+        json['attributes'] as Map<String, dynamic>,
+      ),
+      reviews: json['reviews'] != null
+          ? (json['reviews'] as List)
+          .map((e) => Review.fromJson(e as Map<String, dynamic>))
+          .toList()
+          : null,
+      options: json['options'] != null
+          ? List<String>.from(json['options'] as List)
+          : null,
     );
-  }
-
-  Map<String, dynamic> toJson() {
-    return {
-      '_id': id,
-      'name': name,
-      'image': image,
-      'price': price,
-      'isFavorite': isFavorite,
-      'discount': discount,
-      'category': category,
-      'rating': rating,
-      //...nutrition.toJson(),
-      //'reviews': reviews?.map((e) => e.toJson()).toList(),
-      //'options': options,
-    };
   }
 }

--- a/lib/data/models/product/product_nutrition.dart
+++ b/lib/data/models/product/product_nutrition.dart
@@ -1,8 +1,8 @@
 class ProductNutrition {
-  final int calories;
-  final int carbs;
-  final int fat;
-  final int protein;
+  final String calories;
+  final String carbs;
+  final String fat;
+  final String protein;
 
   const ProductNutrition({
     required this.calories,
@@ -13,10 +13,10 @@ class ProductNutrition {
 
   factory ProductNutrition.fromJson(Map<String, dynamic> json) {
     return ProductNutrition(
-      calories: json['calories'] as int,
-      carbs: json['carbs'] as int,
-      fat: json['fat'] as int,
-      protein: json['protein'] as int,
+      calories: json['calories']?.toString() ?? '',
+      carbs: json['carbs']?.toString() ?? '',
+      fat: json['fat']?.toString() ?? '',
+      protein: json['protein']?.toString() ?? '',
     );
   }
 

--- a/lib/data/models/response/product_list_response.dart
+++ b/lib/data/models/response/product_list_response.dart
@@ -2,13 +2,13 @@ import '../product/product.dart';
 
 class ProductListResponse {
   final List<Product> items;
-  final int total;
-  final String sort;
+  //final int total;
+  //final String sort;
 
   ProductListResponse({
     required this.items,
-    required this.total,
-    required this.sort,
+    //required this.total,
+    //required this.sort,
   });
 
   factory ProductListResponse.fromJson(Map<String, dynamic> json) {
@@ -16,8 +16,8 @@ class ProductListResponse {
       items: (json['items'] as List)
           .map((e) => Product.fromJson(e as Map<String, dynamic>))
           .toList(),
-      total: json['total'] as int,
-      sort: json['sort'] as String,
+      //total: json['total'] as int,
+      //sort: json['sort'] as String,
     );
   }
 }

--- a/lib/data/repositories/product_repository.dart
+++ b/lib/data/repositories/product_repository.dart
@@ -9,14 +9,27 @@ class ProductRepository {
 
   ProductRepository(this._datasource);
 
-  Future<List<Product>> getProducts() async {
-    final response = await _datasource.getProducts();
-
+  Future<List<Product>> getLatestProducts() async {
+    final response = await _datasource.getProducts(sortBy: 'latest');
     if (!response.success) {
       throw Exception(response.message);
     }
-
     return response.data.items;
   }
 
+  Future<List<Product>> getPopularProducts() async {
+    final response = await _datasource.getProducts(sortBy: 'popular');
+    if (!response.success) {
+      throw Exception(response.message);
+    }
+    return response.data.items;
+  }
+
+  Future<List<Product>> getSalesProducts() async {
+    final response = await _datasource.getProducts(sortBy: 'sales');
+    if (!response.success) {
+      throw Exception(response.message);
+    }
+    return response.data.items;
+  }
 }

--- a/lib/presentation/screens/home/home_screen.dart
+++ b/lib/presentation/screens/home/home_screen.dart
@@ -42,7 +42,7 @@ class _HomeScreenState extends State<HomeScreen> {
     super.initState();
 
     Future.microtask(() {
-      context.read<HomeViewmodel>().getProducts();
+      context.read<HomeViewmodel>().getHomeProducts();
     });
   }
 
@@ -117,20 +117,20 @@ class DamDietHomeScreen extends StatelessWidget {
 
               Divider(height: 6, color: AppColors.gray100, thickness: 6),
 
-              ProductList(title: "할인율 큰 상품", productList: viewModel.products),
+              ProductList(title: "따끈따끈! 신제품", productList: viewModel.latestProducts),
 
               Divider(height: 6, color: AppColors.gray100, thickness: 6),
 
               ProductList(
-                title: "다른 고객님들이 많이 구매한 상품",
-                productList: viewModel.products,
+                title: "다른 고객님들이 많이 본 상품",
+                productList: viewModel.popularProducts,
               ),
 
               Divider(height: 6, color: AppColors.gray100, thickness: 6),
 
               ProductList(
-                title: "이런 상품은 어때요?",
-                productList: viewModel.products,
+                title: "판매량 높은 상품",
+                productList: viewModel.salesProducts,
               ),
 
               Divider(height: 6, color: AppColors.gray100, thickness: 6),

--- a/lib/presentation/screens/home/home_screen.dart
+++ b/lib/presentation/screens/home/home_screen.dart
@@ -93,7 +93,6 @@ class DamDietHomeScreen extends StatelessWidget {
         isHome: true,
         action: IconButton(
           onPressed: (){
-            print('구라');
             Navigator.pushNamed(context, AppRoutes.search);
             },
           icon: Icon(Icons.search),
@@ -110,7 +109,11 @@ class DamDietHomeScreen extends StatelessWidget {
 
               Divider(height: 6, color: AppColors.gray100, thickness: 6),
 
-              CategoryList(),
+              CategoryList(onCategorySelected: (category){
+                print(category);
+                //TODO Products 화면에 category 넘기는 작업
+                Navigator.pushNamed(context, AppRoutes.products);
+              }),
 
               Divider(height: 6, color: AppColors.gray100, thickness: 6),
 

--- a/lib/presentation/screens/home/home_viewmodel.dart
+++ b/lib/presentation/screens/home/home_viewmodel.dart
@@ -1,26 +1,37 @@
 import 'package:flutter/widgets.dart';
 import '../../../data/models/product/product.dart';
 import '../../../data/repositories/product_repository.dart';
-
 class HomeViewmodel extends ChangeNotifier {
   final ProductRepository _repository;
 
   HomeViewmodel(this._repository);
 
-  List<Product> _products = [];
-  List<Product> get products => _products;
+  // 최신순 상품
+  List<Product> _latestProducts = [];
+  List<Product> get latestProducts => _latestProducts;
 
+  // 인기순 상품
+  List<Product> _popularProducts = [];
+  List<Product> get popularProducts => _popularProducts;
+
+  // 판매량 순 상품
+  List<Product> _salesProducts = [];
+  List<Product> get salesProducts => _salesProducts;
+
+  // 로딩 상태
   bool _isLoading = false;
   bool get isLoading => _isLoading;
 
-  Future<void> getProducts() async {
+  Future<void> getHomeProducts() async {
     _isLoading = true;
     notifyListeners();
 
     try {
-      _products = await _repository.getProducts();
+      _latestProducts = await _repository.getLatestProducts();
+      _popularProducts = await _repository.getPopularProducts();
+      _salesProducts = await _repository.getSalesProducts();
     } catch (e) {
-      print('Error: $e');
+      print('Error fetching products: $e');
     }
 
     _isLoading = false;

--- a/lib/presentation/screens/home/widgets/category_list.dart
+++ b/lib/presentation/screens/home/widgets/category_list.dart
@@ -1,37 +1,37 @@
 import 'package:flutter/material.dart';
+import '../../../../core/constants/category_constants.dart';
 import 'category_list_item.dart';
 import 'list_title.dart';
 
 class CategoryList extends StatelessWidget {
-  const CategoryList({super.key});
+  final void Function(String) onCategorySelected;
+
+  const CategoryList({super.key, required this.onCategorySelected});
 
   @override
   Widget build(BuildContext context) {
-    return  Column(
+    return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
-        ListTitle( title: '카테고리별 상품 보기',),
+        ListTitle(title: '카테고리별 상품 보기'),
         Container(
-            margin: const EdgeInsets.only(
-                left: 16,
-                bottom: 8
-            ),
-            height: 64.0,
-            child: ListView(
-              scrollDirection: Axis.horizontal,
-              children: <Widget>[
-                CategoryListItem(categoryName: '하루식단세트', imageUrl: 'assets/images/damdiet_logo_5.png'),
-                CategoryListItem(categoryName: '닭가슴살', imageUrl: 'assets/images/damdiet_logo_5.png'),
-                CategoryListItem(categoryName: '볶음밥/도시락', imageUrl: 'assets/images/damdiet_logo_5.png'),
-                CategoryListItem(categoryName: '샐러드', imageUrl: 'assets/images/damdiet_logo_5.png'),
-                CategoryListItem(categoryName: '간식/음료', imageUrl: 'assets/images/damdiet_logo_5.png'),
-              ],
-            )
+          margin: const EdgeInsets.only(left: 16, bottom: 8),
+          height: 64.0,
+          child: ListView.separated(
+            scrollDirection: Axis.horizontal,
+            itemCount: appCategories.length,
+            itemBuilder: (BuildContext context, int index) {
+              return CategoryListItem(
+                category: appCategories[index],
+                onTap: () => onCategorySelected(appCategories[index].nameEn),
+              );
+            },
+            separatorBuilder: (BuildContext context, int index) {
+              return const SizedBox(width: 8); // 구분자 간격
+            },
+          ),
         ),
       ],
     );
   }
-
 }
-
-

--- a/lib/presentation/screens/home/widgets/category_list_item.dart
+++ b/lib/presentation/screens/home/widgets/category_list_item.dart
@@ -1,45 +1,49 @@
 import 'package:damdiet/core/theme/appcolor.dart';
 import 'package:flutter/material.dart';
 
+import '../../../../core/constants/category_constants.dart';
+
 class CategoryListItem extends StatelessWidget {
   const CategoryListItem({
     super.key,
-    required this.categoryName,
-    required this.imageUrl,
+    required this.category,
+    required this.onTap,
   });
 
-  final String categoryName;
-  final String imageUrl;
+  final AppCategory category;
+  final VoidCallback onTap;
 
   @override
   Widget build(BuildContext context) {
-    return Container(
-      width: 74,
-      height: 66,
-      margin: EdgeInsets.only(right:4),
-      child: Column(
-        mainAxisSize: MainAxisSize.min,
-        children: [
-          ClipRRect(
-            borderRadius: BorderRadius.circular(6),
-            child: Image.asset(
-              imageUrl,
-              width: 50,
-              height: 40,
-              fit: BoxFit.fill,
+    return GestureDetector(
+      onTap: onTap,
+      child: Container(
+        width: 74,
+        height: 66,
+        margin: const EdgeInsets.only(right: 4),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            ClipRRect(
+              borderRadius: BorderRadius.circular(6),
+              child: Image.asset(
+                category.imagePath,
+                width: 50,
+                height: 40,
+                fit: BoxFit.fill,
+              ),
             ),
-          ),
-
-          SizedBox(height: 4),
-          Text(
-            categoryName,
-            style: TextStyle(
-              fontFamily: 'PretendardSemiBold',
-              fontSize: 12,
-              color: AppColors.textMain,
+            const SizedBox(height: 4),
+            Text(
+              category.nameKo,
+              style: const TextStyle(
+                fontFamily: 'PretendardSemiBold',
+                fontSize: 12,
+                color: AppColors.textMain,
+              ),
             ),
-          ),
-        ],
+          ],
+        ),
       ),
     );
   }

--- a/lib/presentation/screens/home/widgets/home_banner.dart
+++ b/lib/presentation/screens/home/widgets/home_banner.dart
@@ -1,20 +1,85 @@
-import 'package:flutter/cupertino.dart';
+import 'package:carousel_slider/carousel_slider.dart';
+import 'package:flutter/material.dart';
 
 import '../../../../core/theme/appcolor.dart';
 
-class HomeBanner extends StatelessWidget {
+class HomeBanner extends StatefulWidget {
   const HomeBanner({super.key});
 
   @override
+  State<HomeBanner> createState() => _HomeBannerState();
+}
+
+class _HomeBannerState extends State<HomeBanner> {
+  int _current = 0;
+  final CarouselSliderController _controller = CarouselSliderController();
+
+  final List<String> imageList = [
+    "https://vrthumb.imagetoday.co.kr/2021/08/17/tit245t0142w1.jpg",
+    "https://marketplace.canva.com/EAGfRkfk5SQ/1/0/1280w/canva-%ED%95%91%ED%81%AC%EC%83%89-%EB%B8%94%EB%9E%99-%EA%B7%80%EC%97%AC%EC%9A%B4-3d-%EC%9D%B4%EB%B2%A4%ED%8A%B8-%ED%8A%B9%EA%B0%80-%EC%84%B8%EC%9D%BC-%EA%B3%B5%EC%A7%80-%EC%9D%B8%EC%8A%A4%ED%83%80%EA%B7%B8%EB%9E%A8-%EA%B2%8C%EC%8B%9C%EB%AC%BC-LO3RMq-x7ss.jpg",
+    "https://d2v80xjmx68n4w.cloudfront.net/members/portfolios/GyOyE1730102954.jpg?w=500",
+    "https://i.pinimg.com/736x/13/ca/76/13ca76680f81b30b3f789abf928f7780.jpg",
+    "https://marketplace.canva.com/EAF8BJnZxDI/1/0/1600w/canva-%EB%B9%A8%EA%B0%84%EC%83%89-%ED%9D%B0%EC%83%89-%ED%95%A0%EC%9D%B8-%EC%9D%B4%EB%B2%A4%ED%8A%B8-%EC%9D%B8%EC%8A%A4%ED%83%80%EA%B7%B8%EB%9E%A8-%ED%8F%AC%EC%8A%A4%ED%8A%B8-dcBGvfIv3dc.jpg",
+  ];
+
+  @override
   Widget build(BuildContext context) {
-    return Container(
+    return SizedBox(
       height: 230,
-      width: double.infinity,
-      color: AppColors.primaryColorLight,
-      child: Center(child: Text("배너")),
+      child: Stack(
+        children: [
+          CarouselSlider(
+            items: imageList
+                .map(
+                  (item) => Image.network(
+                    item,
+                    fit: BoxFit.cover,
+                    width: double.infinity,
+                  ),
+                )
+                .toList(),
+            carouselController: _controller,
+            options: CarouselOptions(
+              height: 230,
+              autoPlay: true,
+              enlargeCenterPage: false,
+              viewportFraction: 1.0,
+              onPageChanged: (index, reason) {
+                setState(() {
+                  _current = index;
+                });
+              },
+            ),
+          ),
+          Positioned(
+            bottom: 10,
+            left: 0,
+            right: 0,
+            child: Row(
+              mainAxisAlignment: MainAxisAlignment.center,
+              children: imageList.asMap().entries.map((entry) {
+                return GestureDetector(
+                  onTap: () => _controller.animateToPage(entry.key),
+                  child: Container(
+                    width: 8.0,
+                    height: 8.0,
+                    margin: const EdgeInsets.symmetric(
+                      vertical: 8.0,
+                      horizontal: 4.0,
+                    ),
+                    decoration: BoxDecoration(
+                      shape: BoxShape.circle,
+                      color: (_current == entry.key
+                          ? Colors.white.withOpacity(0.9)
+                          : Colors.white.withOpacity(0.4)),
+                    ),
+                  ),
+                );
+              }).toList(),
+            ),
+          ),
+        ],
+      ),
     );
   }
 }
-
-
-

--- a/lib/presentation/screens/home/widgets/product_list_item.dart
+++ b/lib/presentation/screens/home/widgets/product_list_item.dart
@@ -1,6 +1,7 @@
 import 'package:damdiet/core/theme/appcolor.dart';
 import 'package:flutter/material.dart';
 
+import '../../../../core/utils/formatters.dart';
 import '../../../../data/models/product/product.dart';
 
 
@@ -55,18 +56,39 @@ class ProductListItem extends StatelessWidget {
             overflow: TextOverflow.ellipsis,
           ),
           Row(
-            mainAxisAlignment: MainAxisAlignment.start,
+            mainAxisAlignment: MainAxisAlignment.end,
             children: [
-              SizedBox(width: 4),
-              Text(
-                "30%",
-                style: TextStyle(fontFamily: 'PretendardBold', fontSize: 14, color: AppColors.errorRed),
-              ),
-              SizedBox(width: 4),
-              Text(
-                "${product.price}원",
-                style: TextStyle(fontFamily: 'PretendardMedium', fontSize: 12, color: AppColors.textSub),
-              ),
+              Row(
+                children: [
+                  if (product.discount > 0) ...[
+                    Text(
+                      "${product.discount}%",
+                      style: TextStyle(
+                        fontFamily: 'PretendardBold',
+                        fontSize: 14,
+                        color: AppColors.errorRed,
+                      ),
+                    ),
+                    SizedBox(width: 4),
+                    Text(
+                      formatPrice((product.price * (100 - product.discount) / 100).toInt()),
+                      style: TextStyle(
+                        fontFamily: 'PretendardMedium',
+                        fontSize: 14,
+                        color: AppColors.textSub,
+                      ),
+                    ),
+                  ] else
+                    Text(
+                      formatPrice(product.price),
+                      style: TextStyle(
+                        fontFamily: 'PretendardMedium',
+                        fontSize: 14,
+                        color: AppColors.textSub,
+                      ),
+                    ),
+                ],
+              )
             ],
           ),
         ],

--- a/lib/presentation/screens/home/widgets/product_list_item.dart
+++ b/lib/presentation/screens/home/widgets/product_list_item.dart
@@ -20,11 +20,26 @@ class ProductListItem extends StatelessWidget {
         children: [
           ClipRRect(
             borderRadius: BorderRadius.circular(6),
-            child: Image.asset(
-              "assets/images/damdiet_logo_6.png",
+            child:
+            Image.network(
+              product.image,
               width: 100,
               height: 100,
-              fit: BoxFit.cover,
+              loadingBuilder: (context, child, loadingProgress) {
+                if (loadingProgress == null) return child;
+                return SizedBox(
+                  width: 100,
+                  height: 100,
+                  child: Center(child: CircularProgressIndicator()),
+                );
+              },
+              errorBuilder: (context, error, stackTrace) {
+                return SizedBox(
+                  width: 100,
+                  height: 100,
+                  child: Center(child: Icon(Icons.error)),
+                );
+              },
             ),
           ),
           SizedBox(height: 4),

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -33,6 +33,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.1.2"
+  carousel_slider:
+    dependency: "direct main"
+    description:
+      name: carousel_slider
+      sha256: bcc61735345c9ab5cb81073896579e735f81e35fd588907a393143ea986be8ff
+      url: "https://pub.dev"
+    source: hosted
+    version: "5.1.1"
   characters:
     dependency: transitive
     description:

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -312,6 +312,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.2.1+1"
+  intl:
+    dependency: "direct main"
+    description:
+      name: intl
+      sha256: "3bc132a9dbce73a7e4a21a17d06e1878839ffbf975568bc875c60537824b0c4d"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.18.1"
   js:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -43,6 +43,7 @@ dependencies:
   flutter_rating_bar: ^4.0.1
   flutter_secure_storage: ^9.2.4
   image_picker: ^1.1.2
+  intl: ^0.18.0
 
 
 dev_dependencies:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -44,6 +44,7 @@ dependencies:
   flutter_secure_storage: ^9.2.4
   image_picker: ^1.1.2
   intl: ^0.18.0
+  carousel_slider: ^5.1.1
 
 
 dev_dependencies:


### PR DESCRIPTION
# 🔍 관련 이슈

- 기능정의서 링크
- [노션](https://www.notion.so/21f73873401a80559d31c8df410e5be0?p=21f73873401a80618527f81645a5a756&pm=s)
- [노션](https://www.notion.so/21f73873401a80559d31c8df410e5be0?p=22173873401a80c2abecdc984857d649&pm=s)
- [노션](https://www.notion.so/21f73873401a80559d31c8df410e5be0?p=21f73873401a8006896bf8da200d3a12&pm=s)
- [노션](https://www.notion.so/21f73873401a80559d31c8df410e5be0?p=21f73873401a806cb700d250dd164a26&pm=s)
- 이슈 번호
- #51 
- #49
- #50
- #47 

  
# 💻 작업 내역

- 이 제품은 어때요?
- 다른 고객님들이 많이 구매한 제품
- 할인율 큰 상품
- 홈 배너
  
# 📱 스크린샷(선택사항)
![Screenshot_20250707_152047](https://github.com/user-attachments/assets/d44b3c36-f1b5-4fb8-a2d7-e405b19d9d27)

  
# ⚠️ 기타
이 제품은 어때요? -> 기존에 그냥 상품 리스트 보여주는 것이었으나 latest 쿼리 사용해 최신 등록된 상품 '따끈따끈! 신제품'으로 변경
할인율 높은 상품 -> discount 가 mixin이기도 해서 정렬이 어려울 것 같아 판매순 쿼리 사용해 판매량 높은 상품으로 변경
util에 price formatter 추가