### PR TITLE
feat(#54): 로그아웃(토큰 제거) 후 로그인 화면으로 이동까지 구현

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -9,6 +9,7 @@ import 'package:damdiet/presentation/screens/auth/signup_viewmodel.dart';
 import 'package:damdiet/presentation/screens/community/community_detail_screen.dart';
 import 'package:damdiet/presentation/screens/community/community_write_screen.dart';
 import 'package:damdiet/presentation/screens/kcal_calculator/kcal_calculator_viewmodel.dart';
+import 'package:damdiet/presentation/screens/mypage/mypage/mypage_viewmodel.dart';
 import 'package:damdiet/presentation/screens/mypage/mypage_address_edit_screen.dart';
 import 'package:damdiet/presentation/screens/product_detail/product_detail_viewmodel.dart';
 import 'package:damdiet/presentation/screens/search/search_screen.dart';
@@ -55,9 +56,10 @@ void main() {
           ChangeNotifierProvider(create: (_) => SearchViewModel(SearchRepository(SearchService()))),
           ChangeNotifierProvider(create: (_) => SignInViewModel()),
           ChangeNotifierProvider(create: (_) => NutritionProvider()),
-          ChangeNotifierProvider(create: (_) => KcalCalculatorViewmodel(NutritionRepository(NutritionDataResource())))
+          ChangeNotifierProvider(create: (_) => KcalCalculatorViewmodel(NutritionRepository(NutritionDataResource()))),
           ChangeNotifierProvider(create: (_) => SignUpViewModel()),
-          ChangeNotifierProvider(create: (_) => NutritionProvider())
+          ChangeNotifierProvider(create: (_) => NutritionProvider()),
+          ChangeNotifierProvider(create: (_) => MypageViewModel()),
         ],
         child: const DamDietApp()
     )

--- a/lib/presentation/screens/mypage/mypage/mypage_screen.dart
+++ b/lib/presentation/screens/mypage/mypage/mypage_screen.dart
@@ -1,6 +1,8 @@
+import 'package:damdiet/presentation/screens/mypage/mypage/mypage_viewmodel.dart';
 import 'package:damdiet/presentation/screens/mypage/mypage/widgets/mypage_contents.dart';
 import 'package:damdiet/presentation/screens/mypage/mypage/widgets/mypage_header.dart';
 import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
 
 import '../../../../core/theme/appcolor.dart';
 
@@ -9,13 +11,20 @@ class MyPageScreen extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return Scaffold(
-      backgroundColor: AppColors.primaryColor,
-      body: Stack(
-        children: [
-          const MyPageHeader(),
-          MyPageContents(),
-        ],
+    return ChangeNotifierProvider(
+      create: (_) => MypageViewModel(),
+      child: Scaffold(
+        backgroundColor: AppColors.primaryColor,
+        body: Stack(
+          children: [
+            const MyPageHeader(),
+            Consumer<MypageViewModel>(
+              builder: (context, viewModel, child) {
+                return MyPageContents(viewModel: viewModel);
+              },
+            ),
+          ],
+        ),
       ),
     );
   }

--- a/lib/presentation/screens/mypage/mypage/mypage_viewmodel.dart
+++ b/lib/presentation/screens/mypage/mypage/mypage_viewmodel.dart
@@ -1,0 +1,21 @@
+
+import 'package:flutter/foundation.dart';
+
+import '../../../../core/secure/user_secure_storage.dart';
+
+class MypageViewModel extends ChangeNotifier {
+
+  bool _isLoggedIn = true;
+  bool get isLoggedIn => _isLoggedIn;
+
+  bool _isLoading = true;
+  bool get isLoading => _isLoading;
+
+
+  Future<void> logout() async {
+    await UserSecureStorage.clearTokens();
+    _isLoggedIn = false; // 필요하다면 상태값도 초기화
+    notifyListeners();
+  }
+
+}

--- a/lib/presentation/screens/mypage/mypage/mypage_viewmodel.dart
+++ b/lib/presentation/screens/mypage/mypage/mypage_viewmodel.dart
@@ -5,17 +5,12 @@ import '../../../../core/secure/user_secure_storage.dart';
 
 class MypageViewModel extends ChangeNotifier {
 
-  bool _isLoggedIn = true;
-  bool get isLoggedIn => _isLoggedIn;
-
   bool _isLoading = true;
   bool get isLoading => _isLoading;
 
 
   Future<void> logout() async {
     await UserSecureStorage.clearTokens();
-    _isLoggedIn = false; // 필요하다면 상태값도 초기화
     notifyListeners();
   }
-
 }

--- a/lib/presentation/screens/mypage/mypage/widgets/mypage_contents.dart
+++ b/lib/presentation/screens/mypage/mypage/widgets/mypage_contents.dart
@@ -1,12 +1,15 @@
 import 'package:flutter/material.dart';
 import '../../../../../core/theme/appcolor.dart';
+import '../../../../../core/widgets/confirm_dialog.dart';
 import '../../../../routes/app_routes.dart';
+import '../mypage_viewmodel.dart';
 import 'mypage_icon_menu.dart';
 import 'mypage_list_title.dart';
 import 'mypage_section_title.dart';
 
 class MyPageContents extends StatelessWidget {
-  const MyPageContents({super.key});
+  final MypageViewModel viewModel ;
+  const MyPageContents({super.key, required this.viewModel});
 
   @override
   Widget build(BuildContext context) {
@@ -55,7 +58,22 @@ class MyPageContents extends StatelessWidget {
               const Divider(indent: 16, endIndent: 16, color: AppColors.gray100),
 
               MyPageListTile('로그아웃', () {
-                // TODO: 로그아웃 다이얼로그 처리
+                showDialog(
+                  context: context,
+                  barrierDismissible: false,
+                  builder: (context) => ConfirmDialog(
+                    title: '로그아웃',
+                    content: '정말 로그아웃하시겠습니까?',
+                    onCancel: () {
+                      Navigator.of(context).pop();
+                    },
+                    onConfirm: () async {
+                      Navigator.of(context).pop();
+                      await viewModel.logout();
+                      Navigator.of(context).pushReplacementNamed(AppRoutes.signIn);
+                    },
+                  ),
+                );
               }),
             ],
           ),


### PR DESCRIPTION
# 🔍 관련 이슈

- #54

  
# 💻 작업 내역

- 마이페이지의 로그아웃 버튼 클릭 시 다이알로그 뜨고 네 누르면 토큰 제거 뒤 로그인 화면으로 이동 

  
# 📱 스크린샷(선택사항)
X
  
# ⚠️ 기타
screen 에서 viewModel 쓸 때 Consumer 로 한 번 해봤습니다