### PR TITLE
feat(#43): product_detail -> payment 에 List<OrderItem> argu 추가

### DIFF
--- a/lib/data/models/request/order_request_dto.dart
+++ b/lib/data/models/request/order_request_dto.dart
@@ -1,0 +1,67 @@
+import '../auth/address.dart';
+
+class OrderItem {
+  final String product;
+  final int quantity;
+  final int unitPrice;
+
+  OrderItem({
+    required this.product,
+    required this.quantity,
+    required this.unitPrice,
+  });
+
+  Map<String, dynamic> toJson() {
+    return {
+      'product': product,
+      'quantity': quantity,
+      'unitPrice': unitPrice,
+    };
+  }
+}
+
+class ShippingInfo {
+  final String recipientName;
+  final String recipient;
+  final Address address;
+  final String recipientPhone;
+
+  ShippingInfo({
+    required this.recipientName,
+    required this.recipient,
+    required this.address,
+    required this.recipientPhone,
+  });
+
+  Map<String, dynamic> toJson() {
+    return {
+      'recipientName': recipientName,
+      'recipient': recipient,
+      'address': address.toJson(),
+      'phone': recipientPhone,
+    };
+  }
+}
+
+class OrderRequestDto {
+  final List<OrderItem> items;
+  final ShippingInfo shippingInfo;
+  final String memo;
+  final String paymentMethod;
+
+  OrderRequestDto({
+    required this.items,
+    required this.shippingInfo,
+    required this.memo,
+    required this.paymentMethod,
+  });
+
+  Map<String, dynamic> toJson() {
+    return {
+      'items': items.map((item) => item.toJson()).toList(),
+      'shippingInfo': shippingInfo.toJson(),
+      'memo': memo,
+      'paymentMethod': paymentMethod,
+    };
+  }
+}

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -13,6 +13,7 @@ import 'package:damdiet/presentation/screens/community/community_write_screen.da
 import 'package:damdiet/presentation/screens/kcal_calculator/kcal_calculator_viewmodel.dart';
 import 'package:damdiet/presentation/screens/mypage/mypage/mypage_viewmodel.dart';
 import 'package:damdiet/presentation/screens/mypage/mypage_address_edit_screen.dart';
+import 'package:damdiet/presentation/screens/mypage/mypage_my_orders_screen.dart';
 import 'package:damdiet/presentation/screens/product_detail/product_detail_viewmodel.dart';
 import 'package:damdiet/presentation/screens/search/search_screen.dart';
 import 'package:damdiet/presentation/screens/search/search_viewmodel.dart';
@@ -30,7 +31,6 @@ import 'package:damdiet/presentation/screens/auth/auth_signin_screen.dart';
 import 'package:damdiet/presentation/screens/auth/auth_signup_screen.dart';
 import 'package:damdiet/presentation/screens/mypage/mypage_favorite_product/mypage_favorite_products_screen.dart';
 import 'package:damdiet/presentation/screens/mypage/mypage_my_community_screen.dart';
-import 'package:damdiet/presentation/screens/mypage/mypage_my_orders_screen.dart';
 import 'package:damdiet/presentation/screens/mypage/mypage_my_order_detail/mypage_my_order_details_screen.dart';
 import 'package:damdiet/presentation/screens/mypage/mypage_my_reviews/mypage_my_reviews_screen.dart';
 import 'package:damdiet/presentation/screens/mypage/mypage_password_edit_screen.dart';
@@ -43,6 +43,8 @@ import 'package:damdiet/data/datasource/product_datasource.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_secure_storage/flutter_secure_storage.dart';
 import 'package:provider/provider.dart';
+
+import 'data/models/request/order_request_dto.dart';
 
 
 void main() {
@@ -97,7 +99,6 @@ class DamDietApp extends StatelessWidget {
         AppRoutes.myOrders: (context) => MyPageMyOrdersScreen(),
         AppRoutes.myOrderDetail: (context) => MyPageMyOrderDetailsScreen(),
         AppRoutes.cart: (context) => CartScreen(),
-        AppRoutes.payment: (context) => PaymentScreen(),
         AppRoutes.reviewWrite: (context) => ReviewWriteScreen(),
         AppRoutes.reviewEdit: (context) => ReviewEditScreen(),
         AppRoutes.signIn: (context) => SignInScreen(),
@@ -109,6 +110,12 @@ class DamDietApp extends StatelessWidget {
           final productId = settings.arguments as String;
           return MaterialPageRoute(
             builder: (_) => ProductDetailScreen(productId: productId),
+          );
+        }
+        else if (settings.name == AppRoutes.payment) {
+          final args = settings.arguments as List<OrderItem>;
+          return MaterialPageRoute(
+            builder: (_) => PaymentScreen(orderItems: args),
           );
         }
         return null;

--- a/lib/presentation/screens/mypage/mypage_my_orders/widgets/mypage_order_card_item.dart
+++ b/lib/presentation/screens/mypage/mypage_my_orders/widgets/mypage_order_card_item.dart
@@ -3,7 +3,7 @@ import 'package:damdiet/core/theme/appcolor.dart';
 import '../../mypage_my_orders_screen.dart';
 
 class MyPageOrderCardItem extends StatelessWidget {
-  final OrderItem item;
+  final OrderItem1 item;
 
   const MyPageOrderCardItem({super.key, required this.item});
 

--- a/lib/presentation/screens/mypage/mypage_my_orders_screen.dart
+++ b/lib/presentation/screens/mypage/mypage_my_orders_screen.dart
@@ -5,18 +5,18 @@ import 'package:damdiet/core/theme/appcolor.dart';
 import 'package:damdiet/presentation/screens/mypage/mypage_my_orders/widgets/mypage_orders_empty_view.dart';
 import 'package:damdiet/presentation/screens/mypage/mypage_my_orders/widgets/mypage_order_card.dart';
 
-class OrderItem {
+class OrderItem1 {
   final String imageUrl;
   final String name;
   final String? optionName;
   final int quantity;
   final int price;
-  OrderItem({required this.imageUrl, required this.name, this.optionName, required this.quantity, required this.price});
+  OrderItem1({required this.imageUrl, required this.name, this.optionName, required this.quantity, required this.price});
 }
 
 class Order {
   final String orderDate;
-  final List<OrderItem> items;
+  final List<OrderItem1> items;
   final int totalAmount;
   Order({required this.orderDate, required this.items, required this.totalAmount});
 }
@@ -34,15 +34,15 @@ class _MyPageMyOrdersScreenState extends State<MyPageMyOrdersScreen>{
     Order(
       orderDate: '25.06.18',
       items: [
-        OrderItem(imageUrl: '', name: '담다잇 닭가슴살 블랙페퍼', quantity: 1, price: 7000),
-        OrderItem(imageUrl: '', name: '담다잇 닭가슴살', optionName: '볼케이노 맛', quantity: 2, price: 6300),
+        OrderItem1(imageUrl: '', name: '담다잇 닭가슴살 블랙페퍼', quantity: 1, price: 7000),
+        OrderItem1(imageUrl: '', name: '담다잇 닭가슴살', optionName: '볼케이노 맛', quantity: 2, price: 6300),
       ],
       totalAmount: 19600,
     ),
     Order(
       orderDate: '25.06.18',
       items: [
-        OrderItem(imageUrl: '', name: '담다잇 닭가슴살 블랙페퍼', quantity: 1, price: 7000),
+        OrderItem1(imageUrl: '', name: '담다잇 닭가슴살 블랙페퍼', quantity: 1, price: 7000),
       ],
       totalAmount: 7000,
     ),

--- a/lib/presentation/screens/payment/payment_screen.dart
+++ b/lib/presentation/screens/payment/payment_screen.dart
@@ -7,10 +7,13 @@ import 'package:flutter/material.dart';
 
 import '../../../core/widgets/bottom_cta_button.dart';
 import '../../../core/widgets/product_list_item.dart';
+import '../../../data/models/request/order_request_dto.dart';
 
 
 class PaymentScreen extends StatefulWidget {
-  const PaymentScreen({super.key});
+  final List<OrderItem> orderItems;
+
+  const PaymentScreen({super.key, required this.orderItems});
 
   @override
   State<PaymentScreen> createState() => _PaymentScreenState();
@@ -19,6 +22,7 @@ class PaymentScreen extends StatefulWidget {
 class _PaymentScreenState extends State<PaymentScreen> {
   @override
   Widget build(BuildContext context) {
+    debugPrint("👍👍${widget.orderItems[0].quantity}");
     return Scaffold(
       body: SingleChildScrollView(
         child: Container(

--- a/lib/presentation/screens/product_detail/product_detail_screen.dart
+++ b/lib/presentation/screens/product_detail/product_detail_screen.dart
@@ -9,6 +9,8 @@ import 'package:flutter/material.dart';
 import 'package:flutter_svg/svg.dart';
 import 'package:provider/provider.dart';
 import '../../../core/theme/appcolor.dart';
+import '../../../data/models/request/order_request_dto.dart';
+import '../../routes/app_routes.dart';
 
 class ProductDetailScreen extends StatefulWidget {
   final String productId;
@@ -207,7 +209,29 @@ class _ProductDetailScreenState extends State<ProductDetailScreen> {
             Expanded(
               flex: 2, // 비율 2
               child: ElevatedButton(
-                onPressed: () {},
+                onPressed: () {
+                  if (viewModel.quantity <= 0) {
+                    ScaffoldMessenger.of(context).showSnackBar(
+                      const SnackBar(content: Text('수량을 선택해주세요.')),
+                    );
+                    return;
+                  }
+
+                  final orderItem = OrderItem(
+                    product: viewModel.product.id,
+                    quantity: viewModel.quantity,
+                    unitPrice: hasDiscount
+                        ? (viewModel.product.price * (1 - viewModel.product.discount / 100)).round()
+                        : viewModel.product.price,
+                  );
+
+                  Navigator.pushNamed(
+                    context,
+                    AppRoutes.payment,
+                    arguments: [orderItem],
+                  );
+
+                },
                 style: ElevatedButton.styleFrom(
                   minimumSize: const Size.fromHeight(48),
                   backgroundColor: AppColors.primaryColor,


### PR DESCRIPTION
# 🔍 관련 이슈

- #43 

  
# 💻 작업 내역

- product_detail -> payment 에 List<OrderItem> argu 추가
- payment 화면에서 로그 print 까지 확인
- 수량 선택 안하면 SnackBar

  
# 📱 스크린샷(선택사항)
![image](https://github.com/user-attachments/assets/0778e0c7-8344-4539-919a-e4204184bd9f)
수량 2개 선택해서 보내고 payment_screen 에서 수량 찍어본 결과
  
# ⚠️ 기타
OrderItem 기존에 data/models/orders/order_item에 있는데 (받아오는 용)
보낼때와 약간 달라 requset/order_request_dto.dart 에 새로 만듦 (이름이 같긴해서 import시 주의)
나중에 정리 필요할 듯