### PR TITLE
feat(#158): 주문 목록, 상세에서 주문 상태 출력

### DIFF
--- a/lib/core/utils/translateOrderStatus.dart
+++ b/lib/core/utils/translateOrderStatus.dart
@@ -1,0 +1,18 @@
+String translateOrderStatus(String status) {
+  switch (status) {
+    case 'pending':
+      return '결제 완료';
+    case 'confirmed':
+      return '결제 확인 완료';
+    case 'preparing':
+      return '주문 상품 준비 중';
+    case 'shipped':
+      return '배송 시작';
+    case 'cancelled':
+      return '재고 부족으로 인한 취소';
+    case 'refunded':
+      return '고객 요청에 의한 환불';
+    default:
+      return '알 수 없음';
+  }
+}

--- a/lib/presentation/screens/mypage/mypage_my_order_detail/mypage_my_order_details_screen.dart
+++ b/lib/presentation/screens/mypage/mypage_my_order_detail/mypage_my_order_details_screen.dart
@@ -10,6 +10,7 @@ import 'package:damdiet/presentation/screens/mypage/mypage_my_order_detail/widge
 import 'package:provider/provider.dart';
 
 import '../../../../core/utils/extract_date.dart';
+import '../../../../core/utils/translateOrderStatus.dart';
 import '../../../../data/repositories/order_repository.dart';
 import 'order_detail_viewmodel.dart';
 
@@ -77,10 +78,14 @@ class _MyPageMyOrderDetailsScreenState extends State<MyPageMyOrderDetailsScreen>
           children: [
             Padding(
               padding: const EdgeInsets.only(bottom: 12.0),
-              child: Text(extractDate(order.createdAt), style: const TextStyle(
-                  color: AppColors.textMain,
-                  fontSize: 12,
-                  fontFamily: 'PretendardSemiBold')),
+              child:
+              Row(
+                  children: [
+                    Text(extractDate(order.createdAt), style: const TextStyle(fontSize: 12,color: AppColors.textMain, fontFamily: 'PretendardSemiBold')),
+                    const SizedBox(width: 8,),
+                    Text((translateOrderStatus(order.status)), style: const TextStyle(fontSize: 12,color: AppColors.errorRed, fontFamily: 'PretendardSemiBold')),
+                  ]
+              ),
             ),
             const Divider(color: AppColors.gray100, height: 1),
             const SizedBox(height: 12),

--- a/lib/presentation/screens/mypage/mypage_my_orders/widgets/mypage_order_card.dart
+++ b/lib/presentation/screens/mypage/mypage_my_orders/widgets/mypage_order_card.dart
@@ -23,7 +23,7 @@ class MyPageOrderCard extends StatelessWidget {
         child: Column(
           crossAxisAlignment: CrossAxisAlignment.start,
           children: [
-            MyPageOrderCardHeader(orderDate: order.createdAt, orderId: order.id),
+            MyPageOrderCardHeader(orderDate: order.createdAt, orderId: order.id, status: order.status,),
             const Divider(color: AppColors.gray100, height: 1),
             const SizedBox(height: 16),
             ListView.separated(

--- a/lib/presentation/screens/mypage/mypage_my_orders/widgets/mypage_order_card_header.dart
+++ b/lib/presentation/screens/mypage/mypage_my_orders/widgets/mypage_order_card_header.dart
@@ -1,4 +1,5 @@
 import 'package:damdiet/core/utils/extract_date.dart';
+import 'package:damdiet/core/utils/translateOrderStatus.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_svg/flutter_svg.dart';
 import 'package:damdiet/core/theme/appcolor.dart';
@@ -7,15 +8,22 @@ import 'package:damdiet/presentation/routes/app_routes.dart';
 class MyPageOrderCardHeader extends StatelessWidget {
   final String orderDate;
   final String orderId;
+  final String status;
 
-  const MyPageOrderCardHeader({super.key, required this.orderDate, required this.orderId});
+  const MyPageOrderCardHeader({super.key, required this.orderDate, required this.orderId, required this.status});
 
   @override
   Widget build(BuildContext context) {
     return Row(
       mainAxisAlignment: MainAxisAlignment.spaceBetween,
       children: [
-        Text(extractDate(orderDate), style: const TextStyle(fontSize: 12,color: AppColors.textMain, fontFamily: 'PretendardSemiBold')),
+        Row(
+          children: [
+            Text(extractDate(orderDate), style: const TextStyle(fontSize: 12,color: AppColors.textMain, fontFamily: 'PretendardSemiBold')),
+            const SizedBox(width: 8,),
+            Text((translateOrderStatus(status)), style: const TextStyle(fontSize: 12,color: AppColors.errorRed, fontFamily: 'PretendardSemiBold')),
+          ]
+        ),
         TextButton(
           onPressed: () { Navigator.pushNamed(
             context,


### PR DESCRIPTION
# 🔍 관련 이슈

- #158

  
# 💻 작업 내역

- 주문 목록과 상세에서 주문 상태 보여주도록 추가

  
# 📱 스크린샷(선택사항)
<img width="315" height="194" alt="image" src="https://github.com/user-attachments/assets/1c35ef3d-7978-4d33-a4a3-9aeac45a05d9" />
<img width="318" height="182" alt="image" src="https://github.com/user-attachments/assets/494d8ac8-02e6-460f-bda6-82d3b044bbd2" />

  
# ⚠️ 기타
