### PR TITLE
fix: 영양상세 다이얼로그 닫으면 키보드 올라오는 버그 수정

### DIFF
--- a/lib/presentation/screens/kcal_calculator/widgets/kcal_nutrition_dialog.dart
+++ b/lib/presentation/screens/kcal_calculator/widgets/kcal_nutrition_dialog.dart
@@ -106,7 +106,10 @@ class KcalNutritionDialog extends StatelessWidget {
       ),
       actions: [
         TextButton(
-          onPressed: Navigator.of(context).pop,
+          onPressed: () {
+            Navigator.pop(context);
+            FocusScope.of(context).unfocus();
+          },
           child: Text(
             '닫기',
             style: TextStyle(


### PR DESCRIPTION
# 🔍 관련 이슈

-

  
# 💻 작업 내역

- 영양상세 다이얼로그 닫으면 키보드 올라오는 버그 수정

  
# 📱 스크린샷(선택사항)

  
# ⚠️ 기타
